### PR TITLE
prevent enemies in splash area array from being updated after the death of catapult unit

### DIFF
--- a/Scripts/Managers/game_manager.gd
+++ b/Scripts/Managers/game_manager.gd
@@ -131,7 +131,7 @@ func money_changed(amount : int):
 		coin_counter.text = "+" + str(amount - money_remaining)
 	$UI/Coins.play("fade_in")
 	var tween = coin_text.create_tween()
-	tween.tween_method(set_label_text, money_remaining, amount, 1).set_delay(1)
+	tween.tween_method(set_label_text, money_remaining, amount, 0.6)
 	money_remaining = amount
 
 func set_label_text(value: int):

--- a/Scripts/Units/unit.gd
+++ b/Scripts/Units/unit.gd
@@ -457,4 +457,5 @@ func _on_splash_location_area_entered(area):
 
 
 func _on_splash_location_area_exited(area):
-	enemies_in_splash_zone.erase(area.get_parent())
+	if(alive):
+		enemies_in_splash_zone.erase(area.get_parent())


### PR DESCRIPTION
also sped up coin animation