### PR TITLE
Game freezing bug fix - SEE DESC

### DIFF
--- a/Scripts/Units/unit.gd
+++ b/Scripts/Units/unit.gd
@@ -337,7 +337,9 @@ func skill(phase : String):
 						skill_instance.target = enemies_in_range[enemy_chosen]
 					unit_number += 1
 					skills_spawned += 1
-			#No units in range or reloading
+					if(skill_instance.target == null):
+						skill_instance.queue_free()
+			#No units in range
 			else:
 				#Check if there is a unit in front of you
 				if(movement_locations[0].movement_tile != null and movement_locations[0].movement_tile.units_on_tile.size() > 0):


### PR DESCRIPTION
Skills weren't calling queue_free() if the unit they targeted was killed before they reached their target location. So they perpetually waited thus causing skill_holder to never be ready to move to the next tick.